### PR TITLE
Remove quotes from table_name.

### DIFF
--- a/src/de/bezier/data/sql/PostgreSQL.java
+++ b/src/de/bezier/data/sql/PostgreSQL.java
@@ -67,7 +67,7 @@ extends de.bezier.data.sql.SQL
 		if ( tableNames == null )
 		{
 			tableNames = new ArrayList<String>();
-	        query( "SELECT relname AS 'table_name' FROM pg_stat_user_tables WHERE schemaname='public'" );
+	        query( "SELECT relname AS table_name FROM pg_stat_user_tables WHERE schemaname='public'" );
 			while ( next() ) {
 				tableNames.add( getObject("table_name").toString() );
 			}


### PR DESCRIPTION
@benfry, I initially [submitted this pr to fjenett/sql-library-processing](https://github.com/fjenett/sql-library-processing/pull/17) but yours seems to be the most up to date branch. Bit confusing. Anyway.

I'm seeing this error when trying to connect a Processing 3.3.7 sketch to my local PostgreSQL database
```
postgres=# ERROR:  syntax error at or near "'table_name'" at character 19
STATEMENT:  SELECT relname AS 'table_name' FROM pg_stat_user_tables WHERE schemaname='public'
```
and it's the same one discussed in this [forum thread from 2015](https://forum.processing.org/two/discussion/11259/about-beziersqlib-with-postgresql).

Would really rather not resort to something other than PostgreSQL. Happy to get any guidance or feedback on how to address this, thanks.